### PR TITLE
Add UnitConversion class

### DIFF
--- a/datasource/datasource.owl
+++ b/datasource/datasource.owl
@@ -2317,6 +2317,17 @@ Specific :CombinationMethod approaches can be used to this aim</rdfs:comment>
     
 
 
+    <!-- http://www.metaclip.org/datasource/datasource.owl#UnitConversion -->
+
+    <owl:Class rdf:about="http://www.metaclip.org/datasource/datasource.owl#UnitConversion">
+        <rdfs:subClassOf rdf:resource="http://www.metaclip.org/datasource/datasource.owl#Transformation"/>
+        <dc:description xml:lang="en">Unit conversion represents the process of transforming a measurement value from one unit of measurement to another within a defined system. This class is used to define conversion factors, rules, and relationships between different units.</dc:description>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.metaclip.org/datasource/datasource.owl</rdfs:isDefinedBy>
+        <rdfs:label xml:lang="en">Unit conversion</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://www.metaclip.org/datasource/datasource.owl#ValidationTime -->
 
     <owl:Class rdf:about="http://www.metaclip.org/datasource/datasource.owl#ValidationTime">

--- a/datasource/datasource.owl
+++ b/datasource/datasource.owl
@@ -709,6 +709,19 @@ For example, a near-surface variable might have dimensions like &quot;longitude,
     
 
 
+    <!-- http://www.metaclip.org/datasource/datasource.owl#hadUnitConversion -->
+
+    <owl:ObjectProperty rdf:about="http://www.metaclip.org/datasource/datasource.owl#hadUnitConversion">
+        <rdfs:subPropertyOf rdf:resource="http://www.metaclip.org/datasource/datasource.owl#hadDerivation"/>
+        <rdfs:domain rdf:resource="http://www.metaclip.org/datasource/datasource.owl#Variable"/>
+        <rdfs:range rdf:resource="http://www.metaclip.org/datasource/datasource.owl#Variable"/>
+        <rdfs:comment xml:lang="en">hadUnitConversion is used to describe cases where a unit conversion has been applied to a variable, leading to a transformed version of that variable. </rdfs:comment>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.metaclip.org/datasource/datasource.owl</rdfs:isDefinedBy>
+        <rdfs:label>hadUnitConversion</rdfs:label>
+    </owl:ObjectProperty>
+
+
+
     <!-- http://www.metaclip.org/datasource/datasource.owl#hasAerosolModelComponent -->
 
     <owl:ObjectProperty rdf:about="http://www.metaclip.org/datasource/datasource.owl#hasAerosolModelComponent">


### PR DESCRIPTION
Hi @jbedia, 

I added `ds:UnitConversion` class as a subclass of `ds:Transformation`, with the following `dc:description`: `Unit conversion represents the process of transforming a measurement value from one unit of measurement to another within a defined system. This class is used to define conversion factors, rules, and relationships between different units.`

Let me know your thoughts.

Thanks!